### PR TITLE
feat: v1.1.4: 도감에서 볼수 없는 아이템 "/랭킹 아이템" 추천에서 숨기기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'com.doubledeltas'
-version = '1.1.3'
+version = '1.1.4'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/doubledeltas/minecollector/command/impl/ranking/RankingItemCommand.java
+++ b/src/main/java/com/doubledeltas/minecollector/command/impl/ranking/RankingItemCommand.java
@@ -1,5 +1,6 @@
 package com.doubledeltas.minecollector.command.impl.ranking;
 
+import com.doubledeltas.minecollector.MineCollector;
 import com.doubledeltas.minecollector.command.CommandNode;
 import com.doubledeltas.minecollector.data.DataManager;
 import com.doubledeltas.minecollector.data.GameData;
@@ -13,6 +14,7 @@ import net.md_5.bungee.api.chat.TranslatableComponent;
 import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.Arrays;
@@ -87,6 +89,10 @@ public class RankingItemCommand extends CommandNode {
             return List.of();
 
         return Arrays.stream(Material.values())
+                .filter(material -> sender.isOp()
+                        || !MineCollector.getInstance().getMcolConfig().getGame().isHideUnknownCollection()
+                        || DataManager.getData((Player) sender).getCollection(material) > 0
+                )
                 .map(material -> material.getKey().toString())
                 .collect(Collectors.toList());
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-# MineCollector v1.1.1
+# MineCollector v1.1.4
 #
 # 마인콜렉터 설정 파일입니다.
 # This is MineCollector configuration file.


### PR DESCRIPTION
* "/랭킹 아이템" 명령어의 다음 파라미터(아이템 key 이름 목록)로 아이템 종류를 미리 알 수 있다는 문제가 있어, 다음 중 어느 한 조건이라도 만족할 때만 아이템 이름이 Tab 추천 목록에 보이도록 수정했습니다.
  * 실행자가 OP일 때 (콘솔 포함)
  * config 설정에서, "hide unknown collection"이 false일 때 -- 즉, 수집하지 않은 아이템도 도감에서 볼 수 있을 때
  * 실행자가 1개 이상 수집한 아이템일 때
* config.yml 파일의 버전을 업데이트했습니다.